### PR TITLE
Should fix the backfill bug

### DIFF
--- a/src/main/kotlin/de/bigboot/ggtools/fang/service/QueueMessageService.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/service/QueueMessageService.kt
@@ -522,7 +522,7 @@ class QueueMessageService : AutostartService, KoinComponent {
         event.deferEdit().awaitSafe()
 
         val request = matchReuests[button.matchId] ?: return
-        if(request.pop.players.contains(event.interaction.user.id.asLong())) {
+        if(request.pop.allPlayers.contains(event.interaction.user.id.asLong())) {
             request.finishedPlayers += event.interaction.user.id.asLong()
 
             if(request.finishedPlayers.size >= 2) {


### PR DESCRIPTION
Aimed at fixing the bug in which a queue repop results in the match never ending.

Calling allPlayers in this line should let any player in the match interact with GG instead of just the ones who were backfilled in the repop. This was probably the main cause of that bug.

Another possible solution could be to add a timer on how long a match can last, but risks ending matches prematurely.