### PR TITLE
migrations will work on mysql

### DIFF
--- a/src/main/kotlin/de/bigboot/ggtools/fang/db/Preference.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/db/Preference.kt
@@ -17,5 +17,5 @@ class Preference(id: EntityID<UUID>) : UUIDEntity(id) {
 object Preferences : UUIDTable() {
     val snowflake = long("snowflake")
     val directMessage = bool("direct_message").default(true)
-    val preferredServers = text("preferred_servers")
+    val preferredServers = text("preferred_servers").default("NA,EU")
 }

--- a/src/main/kotlin/de/bigboot/ggtools/fang/db/migrations/V10__add_user_preferences.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/db/migrations/V10__add_user_preferences.kt
@@ -14,7 +14,7 @@ class V10__add_user_preferences : BaseJavaMigration() {
 
         context.connection.prepareStatement("""
         |alter table Preferences
-        |    add preferred_servers text default 'NA,EU';
+        |    add preferred_servers text;
         """.trimMargin()).execute()
     }
 }


### PR DESCRIPTION
For me the current migrations in place did not work on mysql. These changes made it so that it worked for me and it did not *look* to break anything. I have not done much testing on it but I could join queue and it gave me both flags off the bat. When you used to run it, it would give you this error:
```
BLOB, TEXT, GEOMETRY or JSON column 'preferred_servers' can't have a default value
```