### PR TITLE
Ping everyone for mapvote

### DIFF
--- a/src/main/kotlin/de/bigboot/ggtools/fang/service/QueueMessageService.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/service/QueueMessageService.kt
@@ -118,8 +118,6 @@ class QueueMessageService : AutostartService, KoinComponent {
         if(request.state != MatchState.MAP_VOTE) return
 
         request.message.editCompat {
-            content(request.pop.allPlayers.joinToString(" ") { "<@$it>" })
-
             addEmbedCompat {
                 title("Map vote")
 

--- a/src/main/kotlin/de/bigboot/ggtools/fang/service/QueueMessageService.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/service/QueueMessageService.kt
@@ -44,7 +44,7 @@ data class MatchRequest(
     val pop: MatchService.Pop,
     val missingPlayers: MutableSet<Long>,
     val matchReady: CompletableFuture<Unit>,
-    val message: Message,
+    var message: Message,
     val finishedPlayers: MutableSet<Long> = mutableSetOf(),
     val dropPlayers: MutableSet<Long> = mutableSetOf(),
     val mapVotes: MutableMap<Long, String> = mutableMapOf(),
@@ -118,6 +118,8 @@ class QueueMessageService : AutostartService, KoinComponent {
         if(request.state != MatchState.MAP_VOTE) return
 
         request.message.editCompat {
+            content(request.pop.allPlayers.joinToString(" ") { "<@$it>" })
+
             addEmbedCompat {
                 title("Map vote")
 
@@ -230,6 +232,11 @@ class QueueMessageService : AutostartService, KoinComponent {
         request.state = MatchState.MAP_VOTE
         request.mapVoteEnd = Instant.now().plusSeconds(Config.bot.mapvote_time.toLong())
 
+        request.message.delete().await()
+        matchReuests[matchId]!!.message = request.message.channel.awaitSingle().createMessageCompat {
+            content(request.pop.allPlayers.joinToString(" ") { "<@$it>" })
+        }.awaitSingle()
+        
         updateMapVoteMessage(matchId)
 
         CoroutineScope(Dispatchers.Default).launch {


### PR DESCRIPTION
This makes it so that it will ping everyone for map vote. Most people would not realize that the map vote actually went off because they click accept and go back to match-hub. This should help so people can still go back to match-hub and not worry about some person taking a long time to ready and not seeing the map vote. This also makes it so that everyones name is at the top of the msg so it has a yellow background. As seen here 
![image](https://user-images.githubusercontent.com/29708070/198694476-318cb420-c242-4c54-8514-87bba4001fc9.png)
I did not accept but then got back filled so what used to happen is only my name would be at the top but now everyones name in the game is at the top. This would be helpful if there are multiple games so you know which is yours.