### PR TITLE
fix nine players bug

### DIFF
--- a/src/main/kotlin/de/bigboot/ggtools/fang/service/MatchService.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/service/MatchService.kt
@@ -4,6 +4,8 @@ interface MatchService {
 
     fun join(queue: String, snowflake: Long): Boolean
 
+    fun joinInteration(queue: String, snowflake: Long, force: Boolean): Boolean
+    
     fun leave(queue: String, snowflake: Long, matchOnly: Boolean = false): Boolean
 
     fun canPop(queue: String): Boolean

--- a/src/main/kotlin/de/bigboot/ggtools/fang/service/MatchServiceImpl.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/service/MatchServiceImpl.kt
@@ -24,6 +24,10 @@ class MatchServiceImpl : MatchService, KoinComponent {
     }
 
     override fun join(queue: String, snowflake: Long): Boolean {
+        return joinInteration(queue, snowflake, true);
+    }
+    
+    override fun joinInteration(queue: String, snowflake: Long, force: Boolean): Boolean {
         transaction {
             val player = Player.find { (Players.snowflake eq snowflake) and (Players.queue eq queue) }
                 .firstOrNull() ?: Player.new {
@@ -32,8 +36,9 @@ class MatchServiceImpl : MatchService, KoinComponent {
                 this.joined = System.currentTimeMillis()
                 this.queue = queue
             }
-
-            player.inMatch = false
+            if (force) {
+                player.inMatch = false
+            }
         }
         return true
     }

--- a/src/main/kotlin/de/bigboot/ggtools/fang/service/QueueMessageService.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/service/QueueMessageService.kt
@@ -394,7 +394,7 @@ class QueueMessageService : AutostartService, KoinComponent {
 
     private suspend fun handleInteraction(event: ComponentInteractionEvent, button: ButtonJoin) {
         event.deferEdit().awaitSafe()
-        matchService.join(button.queue, event.interaction.user.id.asLong())
+        matchService.joinInteration(button.queue, event.interaction.user.id.asLong(), false)
         updateQueueMessage(button.queue)
         return
     }


### PR DESCRIPTION
This should fix #8 , I will say the way I fixed it is a little bit "hacky". I did this because I dont have a Kotlin editor to automatically update all the times the function is called. This could cause a by product that if the bot freaks out for some reason and a game does not ever end, then the people in this bugged game wont ever be able to join queue. This problem has happened a few times with newer people to the bot as they dont know exactly that it will auto place them back, and this should fix that.