### PR TITLE
Add option to remove region split

### DIFF
--- a/src/main/kotlin/de/bigboot/ggtools/fang/Config.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/Config.kt
@@ -36,6 +36,7 @@ data class QueueConfig(
     val name: String,
     val channel: String,
     val enable_highscore: Boolean = false,
+    val region_split: Boolean = true,
 )
 
 @JsonClass(generateAdapter = true)

--- a/src/main/kotlin/de/bigboot/ggtools/fang/service/MatchServiceImpl.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/service/MatchServiceImpl.kt
@@ -76,28 +76,31 @@ class MatchServiceImpl : MatchService, KoinComponent {
 
             val requiredPlayers = Config.bot.required_players - previousPlayers.size
 
+            
+            val (queueServer, players) = when (Config.bot.queues.filter { it.name == queue }.single().region_split) {
+                true -> kotlin.run {
+                    for(i in requiredPlayers until possiblePlayers.size) {
+                        val players = possibleServers
+                            .map { Pair(it, possiblePlayers
+                                .take(i)
+                                .filter { (_, prefs) -> prefs.preferredServers.contains(it) }
+                                .toList()
+                            )}
+                            .maxBy { (_, players) -> players.size }
 
-            val (queueServer, players) = kotlin.run {
-                for(i in requiredPlayers until possiblePlayers.size) {
-                    val players = possibleServers
+                        if (players.second.size >= requiredPlayers) {
+                            return@run players
+                        }
+                    }
+
+                    return@run possibleServers
                         .map { Pair(it, possiblePlayers
-                            .take(i)
                             .filter { (_, prefs) -> prefs.preferredServers.contains(it) }
                             .toList()
                         )}
                         .maxBy { (_, players) -> players.size }
-
-                    if (players.second.size >= requiredPlayers) {
-                        return@run players
-                    }
                 }
-
-                return@run possibleServers
-                    .map { Pair(it, possiblePlayers
-                        .filter { (_, prefs) -> prefs.preferredServers.contains(it) }
-                        .toList()
-                    )}
-                    .maxBy { (_, players) -> players.size }
+                false -> Pair(null, possiblePlayers.take(requiredPlayers))
             }
 
             for ((player, _) in players)
@@ -129,10 +132,15 @@ class MatchServiceImpl : MatchService, KoinComponent {
 
     override fun getNumPlayers(queue: String, server: String?) = transaction(database) {
         val players = getPlayers(queue)
-        val servers = server?.let { setOf(it) } ?: setOf("NA", "EU")
+        if (Config.bot.queues.filter { it.name == queue }.single().region_split) {
+            val servers = server?.let { setOf(it) } ?: setOf("NA", "EU")
 
-        servers.map { players.filter { player -> player.preferredServers.contains(it)} }
-            .maxOf { it.count() }
-            .toLong()
+            servers.map { players.filter { player -> player.preferredServers.contains(it)} }
+                .maxOf { it.count() }
+                .toLong()
+        }
+        else {
+            players.count().toLong()
+        }
     }
 }


### PR DESCRIPTION
This is going to make it a config item to remove region split. I think if there is a time where a queue does not need it this option could be helpful. If you have the `region_split` option on for the queue, it could look something like this 
![image](https://user-images.githubusercontent.com/29708070/201527342-ee359508-be0f-4d67-bb03-df65de8f55c4.png)
but if you turn it off you are going to get into a game.
![image](https://user-images.githubusercontent.com/29708070/201527362-a2c98eb5-aa23-4916-9413-3e5f499bfcee.png)
In the queue it is going to remove the icons in the queue 
![image](https://user-images.githubusercontent.com/29708070/201527394-bb1e28a0-fff6-4ba6-a0e2-54f32f04ab61.png)
Once you are in a game it is going to also remove the Preferred server section.
![image](https://user-images.githubusercontent.com/29708070/201527819-308ba10a-54a4-4852-9cd7-030930a4f346.png)
The default value is going to be true. I also think that this should be a per queue basis because there might be a time in the future where you would want a queue to not be region based.
