### PR TITLE
Add ability to have a acceptable join time

### DIFF
--- a/src/main/kotlin/de/bigboot/ggtools/fang/Config.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/Config.kt
@@ -49,7 +49,7 @@ data class BotConfig(
     val log_level: String = "info",
     val queues: List<QueueConfig> = listOf(),
     val highscore_channel: String = "",
-    val acceptable_join_time: Int = 600,
+    val time_to_join: Int = 600,
 )
 
 @JsonClass(generateAdapter = true)

--- a/src/main/kotlin/de/bigboot/ggtools/fang/Config.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/Config.kt
@@ -49,6 +49,7 @@ data class BotConfig(
     val log_level: String = "info",
     val queues: List<QueueConfig> = listOf(),
     val highscore_channel: String = "",
+    val acceptable_join_time: Int = 600,
 )
 
 @JsonClass(generateAdapter = true)

--- a/src/main/kotlin/de/bigboot/ggtools/fang/service/ChangelogServiceImpl.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/service/ChangelogServiceImpl.kt
@@ -80,6 +80,9 @@ private val CHANGELOG = listOf(
         "Fix not pinging everyone for mapvote",
         "Fix missing players sometimes includes players who already accepted",
         "Fix a bug that could cause players to be missing from the final match ready notification",
+    ),
+    listOf(
+        "Add ability to have a time to join"
     )
 )
 

--- a/src/main/kotlin/de/bigboot/ggtools/fang/service/QueueMessageService.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/service/QueueMessageService.kt
@@ -55,6 +55,7 @@ data class MatchRequest(
     var openUrl: String? =null,
     var creatures: Triple<String?, String?, String?> = Triple(null, null, null),
     var state: MatchState = MatchState.QUEUE_POP,
+    var acceptableTime: Instant? = null,
 ) {
     fun getMapVoteResult() = mapVotes
         .values
@@ -175,6 +176,13 @@ class QueueMessageService : AutostartService, KoinComponent {
                 }
 
                 addField("Players", request.pop.allPlayers.joinToString(" ") { "<@$it>" }, false)
+                
+                if(request.acceptableTime != null) {
+                    addField("Acceptable time", when {
+                        Instant.now().compareTo(request.acceptableTime) >= 0 -> "If someone is still not in please report them."
+                        else -> "<t:${request.acceptableTime!!.epochSecond}:R>" 
+                    }, false)
+                }
 
                 addComponent(ActionRow.of(components.map { it.component() }))
             }
@@ -245,7 +253,7 @@ class QueueMessageService : AutostartService, KoinComponent {
 
     private suspend fun handleMapVoteFinished(matchId: UUID) {
         val request = matchReuests[matchId] ?: return
-
+        
         request.state = MatchState.MATCH_READY
         updateMatchReadyMessage(matchId)
 
@@ -550,7 +558,7 @@ class QueueMessageService : AutostartService, KoinComponent {
         event
             .deferReply(InteractionCallbackSpec.builder().ephemeral(true).build())
             .awaitSafe()
-
+        
         updateMatchReadyMessage(button.matchId)
 
         event.editReplyCompat {
@@ -617,6 +625,8 @@ class QueueMessageService : AutostartService, KoinComponent {
 
         request.openUrl = start.openUrl
 
+        request.acceptableTime = Instant.now().plusSeconds(Config.bot.acceptable_join_time.toLong());
+
         event.editReplyCompat {
             addEmbedCompat {
                 title("Server setup")
@@ -626,6 +636,11 @@ class QueueMessageService : AutostartService, KoinComponent {
         }.awaitSafe()
 
         updateMatchReadyMessage(button.matchId)
+        
+        CoroutineScope(Dispatchers.Default).launch {
+            delay(Config.bot.acceptable_join_time.seconds)
+            updateMatchReadyMessage(button.matchId)
+        }
     }
 
     private suspend fun handleInteraction(event: ComponentInteractionEvent)

--- a/src/main/kotlin/de/bigboot/ggtools/fang/service/QueueMessageService.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/service/QueueMessageService.kt
@@ -55,7 +55,7 @@ data class MatchRequest(
     var openUrl: String? =null,
     var creatures: Triple<String?, String?, String?> = Triple(null, null, null),
     var state: MatchState = MatchState.QUEUE_POP,
-    var acceptableTime: Instant? = null,
+    var timeToJoin: Instant? = null,
 ) {
     fun getMapVoteResult() = mapVotes
         .values
@@ -177,10 +177,10 @@ class QueueMessageService : AutostartService, KoinComponent {
 
                 addField("Players", request.pop.allPlayers.joinToString(" ") { "<@$it>" }, false)
                 
-                if(request.acceptableTime != null) {
-                    addField("Acceptable time", when {
-                        Instant.now().compareTo(request.acceptableTime) >= 0 -> "If someone is still not in please report them."
-                        else -> "<t:${request.acceptableTime!!.epochSecond}:R>" 
+                if(request.timeToJoin != null) {
+                    addField("Time to join", when {
+                        Instant.now().compareTo(request.timeToJoin) >= 0 -> "If someone is still not in please report them."
+                        else -> "<t:${request.timeToJoin!!.epochSecond}:R>" 
                     }, false)
                 }
 
@@ -625,7 +625,7 @@ class QueueMessageService : AutostartService, KoinComponent {
 
         request.openUrl = start.openUrl
 
-        request.acceptableTime = Instant.now().plusSeconds(Config.bot.acceptable_join_time.toLong());
+        request.timeToJoin = Instant.now().plusSeconds(Config.bot.time_to_join.toLong());
 
         event.editReplyCompat {
             addEmbedCompat {
@@ -638,7 +638,7 @@ class QueueMessageService : AutostartService, KoinComponent {
         updateMatchReadyMessage(button.matchId)
         
         CoroutineScope(Dispatchers.Default).launch {
-            delay(Config.bot.acceptable_join_time.seconds)
+            delay(Config.bot.time_to_join.seconds)
             updateMatchReadyMessage(button.matchId)
         }
     }


### PR DESCRIPTION
This will wait for a server to be up and wait the amount of seconds in the config. As shown here 
![image](https://user-images.githubusercontent.com/29708070/227671778-4ebd6e84-19c3-4c07-9482-c0b8c3a506dd.png)
Once the time is up it will change to this 
![image](https://user-images.githubusercontent.com/29708070/227672016-db05e490-3d16-473d-914f-b81fbdf4e57a.png)
saying that if you take to long you could be reported.