### PR TITLE
Fix Mistforge description if smaller than 150 chars

### DIFF
--- a/src/main/kotlin/de/bigboot/ggtools/fang/service/MistforgeService.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/service/MistforgeService.kt
@@ -173,7 +173,11 @@ class MistforgeService: AutostartService, KoinComponent {
                     title(guide.title)
                     author(guide.username,  "", "https://mistforge.net/customimg/${guide.userId}.png")
                     url("https://mistforge.net/build_viewer?${params}")
-                    description(CopyDown().convert(guide.guide).take(150).plus("..."))
+                    var description = CopyDown().convert(guide.guide)
+                    if (description.length > 150) {
+                        description = description.take(150).plus("...")
+                    }
+                    description(description)
                     
                     addComponent(ActionRow.of(ButtonBuildDetailsId(url.queryParameter("build_id")!!).component()))
                 }


### PR DESCRIPTION
This removes the "..." if the description is less than 150 chars or if there is no description. It used to look like this:

![2023-04-20_20-28_2](https://user-images.githubusercontent.com/29708070/233513706-2528c545-7f67-4e14-b853-fa832474c817.png)

But after the change it gets converted into this:

![2023-04-20_20-31](https://user-images.githubusercontent.com/29708070/233513701-da333961-f3ea-4173-b473-90b7bc0f49ca.png)
