### PR TITLE
Add swap command

### DIFF
--- a/src/main/kotlin/de/bigboot/ggtools/fang/CommandContext.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/CommandContext.kt
@@ -2,6 +2,7 @@ package de.bigboot.ggtools.fang
 
 import discord4j.core.`object`.entity.Guild
 import discord4j.core.`object`.entity.Message
+import discord4j.core.`object`.entity.User
 import discord4j.core.`object`.entity.channel.MessageChannel
 import kotlinx.coroutines.reactive.awaitSingle
 import org.koin.core.component.KoinComponent
@@ -16,6 +17,7 @@ data class CommandContext(
 
     suspend fun channel(): MessageChannel = message.channel.awaitSingle()
     suspend fun guild(): Guild = message.guild.awaitSingle()
+    suspend fun author(): User = message.authorAsMember.awaitSingle()
 
     class Arguments(private val arguments: Map<String, String>) {
         operator fun get(key: String) = arguments.getValue(key)

--- a/src/main/kotlin/de/bigboot/ggtools/fang/commands/Root.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/commands/Root.kt
@@ -5,6 +5,7 @@ import de.bigboot.ggtools.fang.CommandGroupSpec
 import de.bigboot.ggtools.fang.commands.admin.Admin
 import de.bigboot.ggtools.fang.commands.queue.Queue
 import de.bigboot.ggtools.fang.commands.server.Server
+import de.bigboot.ggtools.fang.commands.match.Match
 import de.bigboot.ggtools.fang.utils.createEmbedCompat
 import de.bigboot.ggtools.fang.utils.formatCommandHelp
 import de.bigboot.ggtools.fang.utils.formatCommandTree
@@ -15,6 +16,7 @@ class Root : CommandGroupSpec("", "") {
         group(Admin())
         group(Queue())
         group(Server())
+        group(Match())
 
         command("help", "show this help") {
             onCall {

--- a/src/main/kotlin/de/bigboot/ggtools/fang/commands/match/Match.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/commands/match/Match.kt
@@ -1,0 +1,40 @@
+package de.bigboot.ggtools.fang.commands.match
+
+import de.bigboot.ggtools.fang.CommandGroupBuilder
+import de.bigboot.ggtools.fang.CommandGroupSpec
+import de.bigboot.ggtools.fang.Config
+import de.bigboot.ggtools.fang.service.MatchService
+import de.bigboot.ggtools.fang.service.QueueMessageService
+import de.bigboot.ggtools.fang.utils.*
+import discord4j.common.util.Snowflake
+import kotlinx.coroutines.reactive.awaitSingle
+import org.koin.core.component.inject
+
+class Match : CommandGroupSpec("match", "Commands for matches") {
+    private val matchService by inject<MatchService>()
+    private val queueMessageService by inject<QueueMessageService>()
+
+    override val build: CommandGroupBuilder.() -> Unit = {
+        command("swap", "shows the swap commands for the server") {
+            onCall {
+                val currentServer = queueMessageService.findUser(author().id.asLong());
+
+                if (currentServer != null && currentServer.openUrl != null) {
+                    channel().createMessageCompat {
+                        addEmbedCompat {
+                            title("Swap commands")
+                            description("Leiren: `${currentServer.openUrl}?team=0`\nGrenn: `${currentServer.openUrl}?team=1`")
+                        }
+                    }.awaitSingle()
+                }
+                else {
+                    channel().createMessageCompat {
+                        addEmbedCompat {
+                            description("You are not in a game with a server up")
+                        }
+                    }.awaitSingle()
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/de/bigboot/ggtools/fang/service/QueueMessageService.kt
+++ b/src/main/kotlin/de/bigboot/ggtools/fang/service/QueueMessageService.kt
@@ -397,6 +397,15 @@ class QueueMessageService : AutostartService, KoinComponent {
         ))
     }
 
+    fun findUser(user: Long): MatchRequest? {
+        matchReuests.forEach { (_, request) ->
+            if (request.pop.allPlayers.contains(user)) {
+                return request;
+            }
+        }
+        return null;
+    }
+
     private suspend fun handleInteraction(event: ComponentInteractionEvent, button: ButtonJoin) {
         event.deferEdit().awaitSafe()
         matchService.join(button.queue, event.interaction.user.id.asLong())


### PR DESCRIPTION
This adds the command `!match swap`. This command will look through all of the matches that currently going on and looks for the match that the current user is in. If it does not find a game where the user is playing then it will just give a error response. If you are in a game it will look for if the server has been setup yet. If the server has not been setup yet it will give the error message again. If the server is setup it will use the url to create the swap commands.

I also make this a new command prefix because if I understand how the groups work, you have to give permission for people to use all of the commands under that group. This makes it so that you can give users permission to use the `match` commands without being able to kick users. I also think this makes the command easy to remember and natural to write. 

![2023-05-06_20-04](https://user-images.githubusercontent.com/29708070/236651193-662e569e-2fac-4259-9826-97a2ac6b748e.png)