### PR TITLE
[WIP] Add match making

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven { url = uri("https://jitpack.io") }
 }
 
 group = "de.bigboot.ggtools"
@@ -80,6 +81,9 @@ dependencies {
 
     // CopyDown
     implementation("io.github.furstenheim:copy_down:1.1")
+
+    // Glicko2
+    implementation("io.github.gorgtopalski:glicko2-team:3666e16")
 
     // JUnit
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.1")


### PR DESCRIPTION
This is a work in progress pull request to try and implement some sort of match making. This is also in the works with @Acoliver102 

Currently the plan is to use `Glicko2` to get the rating of user. 

Once the rating of a user is in the database we will use a version of the [knapsack-problem](http://en.wikipedia.org/wiki/Knapsack_problem) to create the teams. There is a minimal function to create these teams to try and be as balanced as possible at https://pl.kotl.in/Cij84blms. For 10 players the amount of lists that will have to be made is `600` (`(n/2)!*n/2`). This should be fast to compute and will give us the closest the teams can be skill wise.

The plan is to try and have some way for servers to know what team won and will report back to fang what team won. Fang will store the teams it made internally allowing for fang to automatically update the scores of users without anyone having to run a command. There might also be a command telling fang to not update the scores for the current game because teams will be played that are are not the fang recommended teams.